### PR TITLE
Add support for embed tags.

### DIFF
--- a/src/TwigFunctionsScanner.php
+++ b/src/TwigFunctionsScanner.php
@@ -15,6 +15,7 @@ namespace Gettext\Scanner;
 use Twig\Environment;
 use Twig\Source;
 use Twig\Node\Expression\FunctionExpression;
+use Twig\Node\ModuleNode;
 
 class TwigFunctionsScanner implements FunctionsScannerInterface
 {
@@ -65,6 +66,14 @@ class TwigFunctionsScanner implements FunctionsScannerInterface
 
         foreach ($token->getIterator() as $subToken) {
             $this->extractGettextFunctions($subToken, $filename, $functions);
+        }
+        
+        if($token instanceof ModuleNode){
+            $embeddedTemplates = $token->getAttribute('embedded_templates');
+            foreach($embeddedTemplates as $embed)
+            {
+                $this->extractGettextFunctions($embed, $filename, $functions);
+            }
         }
     }
 

--- a/src/TwigFunctionsScanner.php
+++ b/src/TwigFunctionsScanner.php
@@ -13,9 +13,9 @@ declare(strict_types = 1);
 namespace Gettext\Scanner;
 
 use Twig\Environment;
-use Twig\Source;
 use Twig\Node\Expression\FunctionExpression;
 use Twig\Node\ModuleNode;
+use Twig\Source;
 
 class TwigFunctionsScanner implements FunctionsScannerInterface
 {
@@ -32,7 +32,7 @@ class TwigFunctionsScanner implements FunctionsScannerInterface
     {
         $name = $node->getAttribute('name');
 
-        if (! in_array($name, $this->functions, true)) {
+        if (!in_array($name, $this->functions, true)) {
             return null;
         }
 
@@ -67,11 +67,10 @@ class TwigFunctionsScanner implements FunctionsScannerInterface
         foreach ($token->getIterator() as $subToken) {
             $this->extractGettextFunctions($subToken, $filename, $functions);
         }
-        
-        if($token instanceof ModuleNode){
+
+        if ($token instanceof ModuleNode) {
             $embeddedTemplates = $token->getAttribute('embedded_templates');
-            foreach($embeddedTemplates as $embed)
-            {
+            foreach ($embeddedTemplates as $embed) {
                 $this->extractGettextFunctions($embed, $filename, $functions);
             }
         }

--- a/tests/TimberFunctionsScannerTest.php
+++ b/tests/TimberFunctionsScannerTest.php
@@ -74,7 +74,7 @@ class TimberFunctionsScannerTest extends TestCase
 
         // text 3
         $function = array_shift($functions);
-        $this->cmp($function, $file, 7, '__', [ 'text 3 (with parenthesis)']);
+        $this->cmp($function, $file, 7, '__', ['text 3 (with parenthesis)']);
 
         // text 4
         $function = array_shift($functions);

--- a/tests/TimberFunctionsScannerTest.php
+++ b/tests/TimberFunctionsScannerTest.php
@@ -62,7 +62,7 @@ class TimberFunctionsScannerTest extends TestCase
         $file = __DIR__ . '/assets/input.html.twig';
         $code = file_get_contents($file);
         $functions = $scanner->scan($code, $file);
-        $this->assertCount(11, $functions);
+        $this->assertCount(12, $functions);
 
         // text 1
         $function = array_shift($functions);

--- a/tests/TimberScannerTest.php
+++ b/tests/TimberScannerTest.php
@@ -36,10 +36,12 @@ class TimberScannerTest extends TestCase
         $scanner = new TimberScanner(Translations::create());
         list('' => $translations) = $this->initAndGetTranslations($scanner);
 
-        $this->assertCount(8, $translations);
+        $this->assertCount(9, $translations);
         $this->assertCount(0, $translations->getHeaders());
 
         $file = __DIR__ . '/assets/default-domain.po';
+        // Note: This test can fail due to `git config core.autocrlf` converting line endings to CRLF
+        // Double check any test error output for `#Warning: Strings contain different line endings!`
         $this->assertSame(
             file_get_contents($file),
             (new PoGenerator())->generateString($translations),
@@ -59,6 +61,8 @@ class TimberScannerTest extends TestCase
         $this->assertCount(1, $tr1);
         $this->assertCount(1, $tr1->getHeaders());
         $file1 = __DIR__ . '/assets/text-domain1.po';
+        // Note: This test can fail due to `git config core.autocrlf` converting line endings to CRLF
+        // Double check any test error output for `#Warning: Strings contain different line endings!`
         $this->assertSame(
             file_get_contents($file1),
             (new PoGenerator())->generateString($tr1),
@@ -68,6 +72,8 @@ class TimberScannerTest extends TestCase
         $this->assertCount(2, $tr2);
         $this->assertCount(1, $tr2->getHeaders());
         $file2 = __DIR__ . '/assets/text-domain2.po';
+        // Note: This test can fail due to `git config core.autocrlf` converting line endings to CRLF
+        // Double check any test error output for `#Warning: Strings contain different line endings!`
         $this->assertSame(
             file_get_contents($file2),
             (new PoGenerator())->generateString($tr2),

--- a/tests/assets/default-domain.po
+++ b/tests/assets/default-domain.po
@@ -36,3 +36,7 @@ msgstr ""
 msgid "text 11 with plural"
 msgid_plural "The plural form"
 msgstr[0] ""
+
+#: ./tests/assets/input.html.twig:26
+msgid "text 12 content inside a block in a embed template"
+msgstr ""

--- a/tests/assets/embed.html.twig
+++ b/tests/assets/embed.html.twig
@@ -1,0 +1,5 @@
+<div class="embedded-content">
+        <h2>{{ __("text 13 header in the embed template, this should be scanned only if the file containing it is.") }}</h2>
+        {% block main %}
+        {% endblock %}
+</div>

--- a/tests/assets/input.html.twig
+++ b/tests/assets/input.html.twig
@@ -21,3 +21,8 @@
     </p>
     <p>
 </div>
+{% embed 'embed.html.twig' %}
+    {% block main %}
+        <p>{{ __("text 12 content inside a block in a embed template") }}</p>
+    {% endblock %}
+{% endembed %}


### PR DESCRIPTION
This change allows the twig scanner to find gettext functions inside of `{% embed ... %}` tags.

**main.twig**
```php
<div class="embed-wrapper">
<h2>{{ __( "string outside of embed") }}</h2>
{% embed 'embed.twig' %}
    {% block main %}
        <h3>{{ __("string inside embed") }}</h3>
        <p>...Further data to put within the embed...</p>
    {% endblock %}
{% endembed %}
</div>
```

**embed.twig**
```php
<div class="mega-embed">
        {% block main %}
        {% endblock %}
<small>{{ __("string within the actual embed file") }}</small>
</div>
```    

Prior to this, only `__( "string outside of embed")` would have been found when scanning main.twig, now `__("string inside embed")` will also be found.

**Note:** This change does not cause `__("string within the actual embed file")` to be found unless embed.twig is also scanned.
`{% embed ... %}` tags are not used to find additional files.
